### PR TITLE
Configurable results per page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,15 @@ target/$(ARCH)/release/nanobot: src/*.rs
 		--rm -t clux/muslrust:stable \
 		cargo build --release
 
+# target/$(ARCH)/release/nanobot: src/*.rs
+# 	docker pull ekidd/rust-musl-builder
+# 	docker run \
+# 		--platform linux/amd64 \
+# 		-v cargo-registry:/root/.cargo/registry \
+# 		-v $$PWD:/home/rust/src \
+# 		--rm -t ekidd/rust-musl-builder \
+# 		cargo build --release
+
 .PHONY: musl
 musl: target/$(ARCH)/release/nanobot | build/
 
@@ -116,5 +125,5 @@ release: target/$(ARCH)/release/nanobot | build/
 	gh release create --draft --prerelease \
 		--title "$(TODAY) Alpha Release" \
 		--generate-notes \
-		v$(TODAY) $(TARGET)
+		v$(TODAY)-tdt $(TARGET)
 	@echo "Please publish GitHub release v$(TODAY)"

--- a/Makefile
+++ b/Makefile
@@ -102,15 +102,6 @@ target/$(ARCH)/release/nanobot: src/*.rs
 		--rm -t clux/muslrust:stable \
 		cargo build --release
 
-# target/$(ARCH)/release/nanobot: src/*.rs
-# 	docker pull ekidd/rust-musl-builder
-# 	docker run \
-# 		--platform linux/amd64 \
-# 		-v cargo-registry:/root/.cargo/registry \
-# 		-v $$PWD:/home/rust/src \
-# 		--rm -t ekidd/rust-musl-builder \
-# 		cargo build --release
-
 .PHONY: musl
 musl: target/$(ARCH)/release/nanobot | build/
 
@@ -125,5 +116,5 @@ release: target/$(ARCH)/release/nanobot | build/
 	gh release create --draft --prerelease \
 		--title "$(TODAY) Alpha Release" \
 		--generate-notes \
-		v$(TODAY)-tdt $(TARGET)
+		v$(TODAY) $(TARGET)
 	@echo "Please publish GitHub release v$(TODAY)"

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ use toml;
 pub struct Config {
     pub config_version: u16,
     pub port: u16,
+    pub results_per_page: u16, 
     pub logging_level: LoggingLevel,
     pub connection: String,
     pub pool: Option<AnyPool>,
@@ -66,6 +67,7 @@ pub struct TomlConfig {
 pub struct NanobotConfig {
     pub config_version: u16,
     pub port: Option<u16>,
+    pub results_per_page: Option<u16>, 
 }
 
 impl Default for NanobotConfig {
@@ -73,6 +75,7 @@ impl Default for NanobotConfig {
         NanobotConfig {
             config_version: 1,
             port: Some(3000),
+            results_per_page: Some(20), // TODO: 100?
         }
     }
 }
@@ -154,6 +157,7 @@ impl Config {
         let config = Config {
             config_version: user.nanobot.config_version,
             port: user.nanobot.port.unwrap_or(3000),
+            results_per_page: user.nanobot.results_per_page.unwrap_or(20), 
             logging_level: user.logging.unwrap_or_default().level.unwrap_or_default(),
             connection: user
                 .database
@@ -315,6 +319,7 @@ pub fn to_toml(config: &Config) -> TomlConfig {
         nanobot: NanobotConfig {
             config_version: config.config_version.clone(),
             port: Some(config.port.clone()),
+            results_per_page: Some(config.results_per_page.clone()),
         },
         logging: Some(LoggingConfig {
             level: Some(config.logging_level.clone()),

--- a/src/get.rs
+++ b/src/get.rs
@@ -4,8 +4,8 @@
 
 use crate::config::Config;
 use crate::sql::{
-    get_count_from_pool, get_message_counts_from_pool, get_table_from_pool, get_total_from_pool,
-    LIMIT_DEFAULT, LIMIT_MAX,
+    get_count_from_pool, get_message_counts_from_pool, get_table_from_pool, get_total_from_pool, 
+    LIMIT_MAX,
 };
 use chrono::prelude::{DateTime, Utc};
 use csv::WriterBuilder;
@@ -115,7 +115,7 @@ pub async fn get_table(
 ) -> Result<String, GetError> {
     let table = unquote(table).unwrap_or(table.to_string());
     let mut select = Select::new(format!("\"{}\"", table));
-    select.limit(LIMIT_DEFAULT);
+    select.limit(usize::from(config.results_per_page));
     get_rows(config, &select, shape, format).await
 }
 
@@ -185,7 +185,7 @@ pub async fn get_rows(
     match select.limit {
         Some(l) if l > LIMIT_MAX => select.limit(LIMIT_MAX),
         Some(l) if l > 0 => select.limit(l),
-        _ => select.limit(LIMIT_DEFAULT),
+        _ => select.limit(usize::from(config.results_per_page)),
     };
 
     let pool = match config.pool.as_ref() {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,7 +1,6 @@
 use crate::{
     config::{Config, ValveConfig},
     get, ldtab, sql,
-    sql::LIMIT_DEFAULT,
     tree_view,
 };
 use ansi_to_html;
@@ -813,8 +812,8 @@ async fn table(
                     Ok(n) => n,
                     Err(e) => return Err(e.to_string().into()),
                 };
-                let pages = row_number / LIMIT_DEFAULT as u32;
-                pages * LIMIT_DEFAULT as u32
+                let pages = row_number / state.config.results_per_page as u32 ;
+                pages * state.config.results_per_page as u32
             };
             let html = format!(
                 r#"<script>

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::error::Error;
 
 pub const LIMIT_MAX: usize = 10000;
-pub const LIMIT_DEFAULT: usize = 20; // TODO: 100?
 
 pub async fn save_table(
     pool: &AnyPool,


### PR DESCRIPTION
Related with the issue https://github.com/brain-bican/taxonomy-development-tools/issues/63

This pull request introduces functionality that allows for the customization of the number of results displayed per page. Users can now specify an optional `results_per_page` configuration (default 20) in the nanobot.toml file to adjust the results quantity per page according to their preferences.